### PR TITLE
result values have the same order as result columNames

### DIFF
--- a/src/main/scala/io/vertx/asyncsql/database/ConnectionHandler.scala
+++ b/src/main/scala/io/vertx/asyncsql/database/ConnectionHandler.scala
@@ -122,9 +122,15 @@ trait ConnectionHandler extends ScalaBusMod with VertxScalaHelpers {
         val fields = (new JsonArray() /: resultSet.columnNames) { (arr, name) =>
           arr.addString(name)
         }
-        val rows = (new JsonArray() /: resultSet) { (arr, rowData) =>
-          arr.add(rowDataToJsonArray(rowData))
-        }
+
+        val rows = Json.arr((for {
+          rowData <- resultSet
+        } yield Json.arr((for {
+          columnName <- resultSet.columnNames
+        } yield {
+          rowData(columnName)
+        }): _*)): _*)
+
         result.putArray("fields", fields)
         result.putArray("results", rows)
       case None =>
@@ -132,6 +138,4 @@ trait ConnectionHandler extends ScalaBusMod with VertxScalaHelpers {
 
     Ok(result)
   }
-
-  private def rowDataToJsonArray(rowData: RowData): JsonArray = Json.arr(rowData.toList: _*)
 }

--- a/src/test/scala/io/vertx/asyncsql/test/mysql/MySqlTest.scala
+++ b/src/test/scala/io/vertx/asyncsql/test/mysql/MySqlTest.scala
@@ -31,6 +31,8 @@ CREATE TABLE """ + tableName + """ (
   @Test
   override def multipleFields(): Unit = super.multipleFields()
   @Test
+  override def multipleFieldsOrder(): Unit = super.multipleFieldsOrder()
+  @Test
   override def createAndDropTable(): Unit = super.createAndDropTable()
   @Test
   override def insertCorrect(): Unit = super.insertCorrect()
@@ -49,8 +51,8 @@ CREATE TABLE """ + tableName + """ (
   @Test
   override def preparedSelect(): Unit = super.preparedSelect()
 
-//  @Ignore("not working currently")
-//  @Test
-//  override def transaction(): Unit = super.transaction()
+  //  @Ignore("not working currently")
+  //  @Test
+  //  override def transaction(): Unit = super.transaction()
 
 }

--- a/src/test/scala/io/vertx/asyncsql/test/postgresql/PostgreSqlTest.scala
+++ b/src/test/scala/io/vertx/asyncsql/test/postgresql/PostgreSqlTest.scala
@@ -17,6 +17,8 @@ class PostgreSqlTest extends SqlTestVerticle with BaseSqlTests {
   @Test
   override def multipleFields(): Unit = super.multipleFields()
   @Test
+  override def multipleFieldsOrder(): Unit = super.multipleFieldsOrder()
+  @Test
   override def createAndDropTable(): Unit = super.createAndDropTable()
   @Test
   override def insertCorrect(): Unit = super.insertCorrect()


### PR DESCRIPTION
The result values had a different order than the result columNames.
With this fix one will be able to match columnNames and result values because they have the same order now.
